### PR TITLE
Add Vite-based React home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local
+.vite
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-empty
+# Dzieje Rzeczypospolitej Szlacheckiej
+
+Prosty projekt startowy w React, stworzony przy pomocy Vite. Zawiera przygotowaną stronę główną przedstawiającą najważniejsze elementy historii Rzeczypospolitej Szlacheckiej.
+
+## Wymagania
+
+- Node.js 18+
+- npm 9+
+
+## Instalacja
+
+```bash
+npm install
+```
+
+## Dostępne skrypty
+
+- `npm run dev` – uruchamia środowisko deweloperskie Vite.
+- `npm run build` – tworzy zoptymalizowaną wersję produkcyjną aplikacji.
+- `npm run preview` – podgląd zbudowanej aplikacji.
+- `npm run lint` – uruchamia ESLinta dla plików źródłowych.
+
+## Struktura projektu
+
+```
+├── index.html
+├── package.json
+├── public
+│   └── vite.svg
+├── src
+│   ├── App.css
+│   ├── App.jsx
+│   ├── index.css
+│   └── main.jsx
+├── eslint.config.js
+└── vite.config.js
+```
+
+## Licencja
+
+Projekt udostępniony na licencji MIT. Możesz go dowolnie rozwijać i wykorzystywać.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,50 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import react from 'eslint-plugin-react';
+
+export default [
+  {
+    ignores: ['dist'],
+  },
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      react,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      'react-refresh/only-export-components': [
+        'warn',
+        {
+          allowConstantExport: true,
+        },
+      ],
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dzieje Rzeczypospolitej Szlacheckiej</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "dzieje-reczypospolitej-szlacheckiej",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.11.1",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^9.11.1",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "globals": "^15.9.0",
+    "vite": "^5.4.1"
+  }
+}

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="shield" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#e0c36a" />
+      <stop offset="100%" stop-color="#b38b2e" />
+    </linearGradient>
+    <linearGradient id="cross" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f5f5f5" />
+      <stop offset="100%" stop-color="#dcdde1" />
+    </linearGradient>
+  </defs>
+  <path
+    fill="url(#shield)"
+    d="M64 8 108 24 100 90 64 120 28 90 20 24 64 8z"
+    stroke="#8a6d23"
+    stroke-width="4"
+    stroke-linejoin="round"
+  />
+  <path
+    fill="none"
+    stroke="url(#cross)"
+    stroke-width="8"
+    stroke-linecap="round"
+    d="M64 28v64m-24-32h48"
+  />
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,238 @@
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  color: #1a202c;
+}
+
+.hero {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  place-items: center;
+  padding: clamp(4rem, 8vw, 8rem) 1.5rem;
+  background: linear-gradient(135deg, #112d4e, #3f72af);
+  color: #f5f7ff;
+  overflow: hidden;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.25), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(255, 255, 255, 0.2), transparent 55%);
+  z-index: -1;
+  opacity: 0.9;
+}
+
+.hero__content {
+  max-width: 60rem;
+  text-align: center;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero__eyebrow {
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  line-height: 1.05;
+  margin: 0;
+}
+
+.hero__subtitle {
+  margin: 0 auto;
+  max-width: 42rem;
+  font-size: 1.15rem;
+  color: rgba(245, 247, 255, 0.9);
+}
+
+.hero__actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.button--primary {
+  background-color: #f9f7f7;
+  color: #112d4e;
+  box-shadow: 0 12px 30px rgba(17, 45, 78, 0.25);
+}
+
+.button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(17, 45, 78, 0.3);
+}
+
+.button--secondary {
+  background-color: transparent;
+  border: 2px solid rgba(245, 247, 255, 0.6);
+  color: #f5f7ff;
+}
+
+.button--secondary:hover {
+  background-color: rgba(245, 247, 255, 0.1);
+}
+
+.section {
+  padding: clamp(3rem, 7vw, 6rem) 1.5rem;
+  background-color: transparent;
+}
+
+.section__title {
+  margin: 0;
+  text-align: center;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.section__lead {
+  margin: 1rem auto 0;
+  max-width: 44rem;
+  text-align: center;
+  color: #4a5568;
+  font-size: 1.05rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.card {
+  background-color: #ffffff;
+  padding: 2rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 40px rgba(17, 45, 78, 0.08);
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(17, 45, 78, 0.05);
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #112d4e;
+}
+
+.card p {
+  margin: 0;
+  color: #4a5568;
+}
+
+.section--accent {
+  background: linear-gradient(120deg, #f5f7ff, #dbe2ef);
+}
+
+.timeline {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 1.75rem;
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 1rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(17, 45, 78, 0.2), rgba(17, 45, 78, 0));
+}
+
+.timeline__entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  padding-left: 1.5rem;
+  position: relative;
+}
+
+.timeline__dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background-color: #3f72af;
+  border: 3px solid #f5f7ff;
+  box-shadow: 0 0 0 4px rgba(63, 114, 175, 0.2);
+  position: absolute;
+  left: 0;
+  top: 0.25rem;
+}
+
+.timeline__content {
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 18px 30px rgba(17, 45, 78, 0.08);
+  border: 1px solid rgba(17, 45, 78, 0.05);
+}
+
+.timeline__content h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #1a202c;
+}
+
+.timeline__content p {
+  margin: 0;
+  color: #4a5568;
+}
+
+.section--cta {
+  text-align: center;
+  background-color: #112d4e;
+  color: #f5f7ff;
+  display: grid;
+  gap: 1rem;
+}
+
+.section--cta p {
+  margin: 0 auto;
+  max-width: 32rem;
+  color: rgba(245, 247, 255, 0.85);
+}
+
+.footer {
+  margin-top: auto;
+  padding: 2rem 1.5rem;
+  background-color: #0f1d33;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .hero__subtitle {
+    font-size: 1rem;
+  }
+
+  .timeline::before {
+    left: 0.5rem;
+  }
+
+  .timeline__entry {
+    padding-left: 1rem;
+  }
+
+  .timeline__dot {
+    left: -0.15rem;
+  }
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,111 @@
+import './App.css';
+
+const highlights = [
+  {
+    title: 'Złota wolność',
+    description:
+      'Unikalny system polityczny oparty na szerokich prawach szlachty i wolnej elekcji władcy.',
+  },
+  {
+    title: 'Różnorodność kulturowa',
+    description:
+      'Mozaika narodów, języków i wyznań, które współtworzyły Rzeczpospolitą Obojga Narodów.',
+  },
+  {
+    title: 'Dziedzictwo prawne',
+    description:
+      'Konstytucja 3 maja i inne reformy jako fundamenty nowoczesnej myśli politycznej w Europie.',
+  },
+];
+
+const timeline = [
+  {
+    period: 'XVI wiek',
+    event: 'Unia lubelska (1569) scala Królestwo Polskie i Wielkie Księstwo Litewskie.',
+  },
+  {
+    period: 'XVII wiek',
+    event: 'Potop szwedzki i wojny kozackie wystawiają państwo na ciężką próbę.',
+  },
+  {
+    period: 'XVIII wiek',
+    event: 'Epoka wielkich reform i uchwalenie Konstytucji 3 maja (1791).',
+  },
+];
+
+function App() {
+  return (
+    <div className="app">
+      <header className="hero">
+        <div className="hero__overlay" />
+        <div className="hero__content">
+          <p className="hero__eyebrow">Historia do odkrycia</p>
+          <h1 className="hero__title">Dzieje Rzeczypospolitej Szlacheckiej</h1>
+          <p className="hero__subtitle">
+            Zanurz się w fascynującą opowieść o państwie, które przez stulecia łączyło
+            kultury, tradycje i ambicje swoich obywateli.
+          </p>
+          <div className="hero__actions">
+            <a className="button button--primary" href="#poznaj">
+              Poznaj historię
+            </a>
+            <a className="button button--secondary" href="#kalendarium">
+              Kalendarium wydarzeń
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section className="section" id="poznaj">
+          <h2 className="section__title">Dlaczego warto poznać tę historię?</h2>
+          <p className="section__lead">
+            Dziedzictwo Rzeczypospolitej Szlacheckiej to coś więcej niż daty i bitwy. To
+            opowieść o wolności, odpowiedzialności i wspólnocie tworzonej przez różnorodne
+            narody.
+          </p>
+          <div className="grid">
+            {highlights.map((item) => (
+              <article key={item.title} className="card">
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section section--accent" id="kalendarium">
+          <h2 className="section__title">Kalendarium kluczowych momentów</h2>
+          <div className="timeline">
+            {timeline.map((entry) => (
+              <div key={entry.period} className="timeline__entry">
+                <div className="timeline__dot" aria-hidden="true" />
+                <div className="timeline__content">
+                  <h3>{entry.period}</h3>
+                  <p>{entry.event}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="section section--cta">
+          <h2>Gotowy na podróż w czasie?</h2>
+          <p>
+            Dołącz do nas i odkryj, jak dziedzictwo Rzeczypospolitej Szlacheckiej wpływa na
+            współczesność.
+          </p>
+          <a className="button button--primary" href="mailto:kontakt@historia.pl">
+            Skontaktuj się z nami
+          </a>
+        </section>
+      </main>
+
+      <footer className="footer">
+        <p>© {new Date().getFullYear()} Historia Rzeczypospolitej. Wszystkie prawa zastrzeżone.</p>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,30 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1a202c;
+  background-color: #f6f5f1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+main {
+  display: block;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite React project with ESLint configuration and useful npm scripts
- implement a stylized home page highlighting kluczowe wątki historii Rzeczypospolitej Szlacheckiej
- add global styles, custom favicon, and refreshed documentation for project usage

## Testing
- npm install *(fails: 403 Forbidden when reaching the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c95147c6588321a3a7295541f82ef0